### PR TITLE
Added installation of udev rule to cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ ADD_CUSTOM_TARGET (distclean @echo cleaning cmake files)
 
 install(FILES package.xml DESTINATION share/libepos2)
 
+# install udev rule for accessing the ftdi device
+INSTALL(FILES doc/91-epos2.rules DESTINATION /etc/udev/rules.d)
+
 IF (UNIX)
   ADD_CUSTOM_COMMAND(
     COMMENT "distribution clean"

--- a/doc/91-epos2.rules
+++ b/doc/91-epos2.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb|usb_device", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="a8b0", GROUP="dialout"
+SUBSYSTEM=="usb|usb_device", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="a8b0", MODE="0660", GROUP="dialout"


### PR DESCRIPTION
The added udev rule allows an communication to ftdi devices to users which are members of the group dialout. 
This resolves a Problem occurring on ubuntu 18.04 where a communication to the ftdi device is not possible with the default system configuration.